### PR TITLE
also exclude clojure.core/list

### DIFF
--- a/src/etcd_clojure/core.clj
+++ b/src/etcd_clojure/core.clj
@@ -2,7 +2,7 @@
   (:use [etcd-clojure.util])
   (:require [clj-http.client :as http])
   (:require [cheshire.core :refer :all])
-  (:refer-clojure :exclude [get set]))
+  (:refer-clojure :exclude [list get set]))
 
 (def ^:private admin-endpoint (atom "http://127.0.0.1:7001"))
 


### PR DESCRIPTION
Hi Antonio.

I noticed that when I wanted to creating an uberjar, while importing etcd-clojure, only works if  `clojure.core/list` is also excluded.

Cheers,
Waldemar 

```
WARNING: list already refers to: #'clojure.core/list in namespace: etcd-clojure.core, being replaced by: #'etcd-clojure.core/list
Exception in thread "main" java.lang.NullPointerException, compiling:(util.clj:5:1)
    at clojure.lang.Compiler$InvokeExpr.eval(Compiler.java:3558)
    at clojure.lang.Compiler.compile1(Compiler.java:7226)
    at clojure.lang.Compiler.compile(Compiler.java:7292)
    at clojure.lang.RT.compile(RT.java:398)
    at clojure.lang.RT.load(RT.java:438)
    at clojure.lang.RT.load(RT.java:411)
    at clojure.core$load$fn__5066.invoke(core.clj:5641)
    at clojure.core$load.doInvoke(core.clj:5640)
    at clojure.lang.RestFn.invoke(RestFn.java:408)
    at clojure.core$load_one.invoke(core.clj:5446)
    at clojure.core$compile$fn__5071.invoke(core.clj:5652)
    at clojure.core$compile.invoke(core.clj:5651)
    at user$eval9.invoke(form-init9085156161100395776.clj:1)
    at clojure.lang.Compiler.eval(Compiler.java:6703)
    at clojure.lang.Compiler.eval(Compiler.java:6693)
    at clojure.lang.Compiler.load(Compiler.java:7130)
    at clojure.lang.Compiler.loadFile(Compiler.java:7086)
    at clojure.main$load_script.invoke(main.clj:274)
    at clojure.main$init_opt.invoke(main.clj:279)
    at clojure.main$initialize.invoke(main.clj:307)
    at clojure.main$null_opt.invoke(main.clj:342)
    at clojure.main$main.doInvoke(main.clj:420)
    at clojure.lang.RestFn.invoke(RestFn.java:421)
    at clojure.lang.Var.invoke(Var.java:383)
    at clojure.lang.AFn.applyToHelper(AFn.java:156)
    at clojure.lang.Var.applyTo(Var.java:700)
    at clojure.main.main(main.java:37)
Caused by: java.lang.NullPointerException
    at clojure.lang.Compiler$ObjExpr.emitVar(Compiler.java:4944)
    at clojure.lang.Compiler$DefExpr.emit(Compiler.java:437)
    at clojure.lang.Compiler.compile1(Compiler.java:7225)
    at clojure.lang.Compiler.compile(Compiler.java:7292)
    at clojure.lang.RT.compile(RT.java:398)
    at clojure.lang.RT.load(RT.java:438)
    at clojure.lang.RT.load(RT.java:411)
    at clojure.core$load$fn__5066.invoke(core.clj:5641)
    at clojure.core$load.doInvoke(core.clj:5640)
    at clojure.lang.RestFn.invoke(RestFn.java:408)
    at clojure.core$load_one.invoke(core.clj:5446)
    at clojure.core$load_lib$fn__5015.invoke(core.clj:5486)
    at clojure.core$load_lib.doInvoke(core.clj:5485)
    at clojure.lang.RestFn.applyTo(RestFn.java:142)
    at clojure.core$apply.invoke(core.clj:626)
    at clojure.core$load_libs.doInvoke(core.clj:5524)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invoke(core.clj:626)
    at clojure.core$require.doInvoke(core.clj:5607)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.lang.Compiler$InvokeExpr.eval(Compiler.java:3553)
    ... 26 more
```
